### PR TITLE
Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /venv/
 **/.cache*
 **/settings.json
+**/cache-playlists.json
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.idea/
 /venv/
 **/.cache*
-**/settings.json
-**/cache-playlists.json
+**/settings.*
+**/cache-playlists.*
 __pycache__

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,8 @@ import tkinter as tk
 from tkinter.ttk import Progressbar, Style
 import threading
 import json
+import re
+from datetime import datetime, timezone
 
 
 class Application(tk.Frame):
@@ -24,6 +26,26 @@ class Application(tk.Frame):
         except FileNotFoundError:
             pass
 
+        self.cache = {'time_created': datetime.now(timezone.utc), 'data': {}}
+        print(self.cache)
+        # Load cache from file
+        try:
+            with open('./data/cache-playlists.json', 'r') as file:
+                self.cache = json.loads(file.read())
+                datetime_str = re.search(r'(\d\d)\/(\d\d)\/(\d\d\d\d) (\d\d):(\d\d):(\d\d)', self.cache['time_created'])
+                current_time = datetime(int(datetime_str.group(3)),
+                                        int(datetime_str.group(2)),
+                                        int(datetime_str.group(1)),
+                                        hour=int(datetime_str.group(4)),
+                                        minute=int(datetime_str.group(5)),
+                                        second=int(datetime_str.group(6)))
+                self.cache['time_created'] = current_time
+        except FileNotFoundError:
+            pass
+
+        #if self.settings['cache']:
+            #self.cache_thread = threading.Thread()
+
         self.create_base_widgets()
 
     def save_and_exit(self):
@@ -32,6 +54,9 @@ class Application(tk.Frame):
         """
         with open('./data/settings.json', 'w+') as file:
             file.write(json.dumps(self.settings, indent=1))
+        with open('./data/cache-playlists.json', 'w+') as file:
+            self.cache['time_created'] = self.cache['time_created'].strftime("%d/%m/%Y %H:%M:%S")
+            file.write(json.dumps(self.cache, indent=1))
         self.master.destroy()
 
     def create_base_widgets(self):

--- a/src/main.py
+++ b/src/main.py
@@ -26,7 +26,7 @@ class Application(tk.Frame):
         except FileNotFoundError:
             pass
 
-        self.cache = {'time_created': datetime.now(timezone.utc), 'data': {}}
+        self.cache = {'time_created': datetime.now(timezone.utc), 'data': None}
         # Load cache from file
         try:
             with open('./data/cache-playlists.json', 'r') as file:
@@ -42,8 +42,9 @@ class Application(tk.Frame):
         except FileNotFoundError:
             pass
 
-        #if self.settings['cache']:
-            #self.cache_thread = threading.Thread()
+        if self.settings['cache']:
+            self.cache_thread = threading.Thread(target=self.cache_playlists_helper)
+            self.cache_thread.start()
 
         self.create_base_widgets()
 
@@ -57,6 +58,10 @@ class Application(tk.Frame):
             self.cache['time_created'] = self.cache['time_created'].strftime("%d/%m/%Y %H:%M:%S")
             file.write(json.dumps(self.cache, indent=1))
         self.master.destroy()
+
+    def cache_playlists_helper(self):
+        playlists = self.spm.get_spotipy_client().current_user_playlists()
+        self.cache['data'] = self.spm.cache_songs_in_playlists(playlists)
 
     def create_base_widgets(self):
         """

--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,6 @@ class Application(tk.Frame):
             pass
 
         self.cache = {'time_created': datetime.now(timezone.utc), 'data': {}}
-        print(self.cache)
         # Load cache from file
         try:
             with open('./data/cache-playlists.json', 'r') as file:

--- a/src/main.py
+++ b/src/main.py
@@ -169,7 +169,7 @@ class Application(tk.Frame):
             if self.settings['cache'] and not self.cache['data'] is None:
                 playlist_uris = set()
                 for playlist_uri in self.cache['data']:
-                    if song_uri in self.cache['data'][playlist_uri]:
+                    if song_uri in self.cache['data'][playlist_uri] and playlist_uri not in self.settings['playlists_exclude']:
                         playlist_uris.add(playlist_uri)
             else:
                 playlist_uris = self.spm.find_song_in_playlists(song_uri, self.settings['playlists_exclude'])

--- a/src/main.py
+++ b/src/main.py
@@ -50,6 +50,9 @@ class Application(tk.Frame):
         self.master.destroy()
 
     def cache_playlists_helper(self):
+        """
+        Sets cache data to correct format of playlists. Function should only called in a thread.
+        """
         playlists = self.spm.get_spotipy_client().current_user_playlists()
         self.cache['data'] = self.spm.cache_songs_in_playlists(playlists)
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,8 +2,7 @@ from src.spotipy_manager import *
 import tkinter as tk
 from tkinter.ttk import Progressbar, Style
 import threading
-import json
-import re
+import pickle
 from datetime import datetime, timezone
 
 
@@ -21,24 +20,16 @@ class Application(tk.Frame):
         self.settings = {'cache': True, 'playlists_exclude': []}
         # Load settings from file
         try:
-            with open('./data/settings.json', 'r') as file:
-                self.settings = json.loads(file.read())
+            with open('./data/settings.pickle', 'rb') as file:
+                self.settings = pickle.load(file)
         except FileNotFoundError:
             pass
 
         self.cache = {'time_created': datetime.now(timezone.utc), 'data': None}
         # Load cache from file
         try:
-            with open('./data/cache-playlists.json', 'r') as file:
-                self.cache = json.loads(file.read())
-                datetime_str = re.search(r'(\d\d)\/(\d\d)\/(\d\d\d\d) (\d\d):(\d\d):(\d\d)', self.cache['time_created'])
-                current_time = datetime(int(datetime_str.group(3)),
-                                        int(datetime_str.group(2)),
-                                        int(datetime_str.group(1)),
-                                        hour=int(datetime_str.group(4)),
-                                        minute=int(datetime_str.group(5)),
-                                        second=int(datetime_str.group(6)))
-                self.cache['time_created'] = current_time
+            with open('./data/cache-playlists.pickle', 'rb') as file:
+                self.cache = pickle.load(file)
         except FileNotFoundError:
             pass
 
@@ -52,11 +43,10 @@ class Application(tk.Frame):
         """
         Saves self.settings to a file and exits
         """
-        with open('./data/settings.json', 'w+') as file:
-            file.write(json.dumps(self.settings, indent=1))
-        with open('./data/cache-playlists.json', 'w+') as file:
-            self.cache['time_created'] = self.cache['time_created'].strftime("%d/%m/%Y %H:%M:%S")
-            file.write(json.dumps(self.cache, indent=1))
+        with open('./data/settings.pickle', 'wb+') as file:
+            pickle.dump(self.settings, file)
+        with open('./data/cache-playlists.pickle', 'wb+') as file:
+            pickle.dump(self.cache, file)
         self.master.destroy()
 
     def cache_playlists_helper(self):

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ class Application(tk.Frame):
         except FileNotFoundError:
             pass
 
-        self.cache = {'time_created': datetime.now(timezone.utc), 'data': None}
+        self.cache = {'date_modified': datetime.now(timezone.utc), 'data': None}
         # Load cache from file
         try:
             with open('./data/cache-playlists.pickle', 'rb') as file:

--- a/src/spotipy_manager.py
+++ b/src/spotipy_manager.py
@@ -100,10 +100,10 @@ class SpotipyManager:
         :return: Dict mapping playlist uri to set of track uris that are within that playlist
         """
         cached_playlists = {}  # Maps playlist uri to a set of track uri's
-        self._sort_songs_helper(playlists, cached_playlists)
+        self._cache_songs_helper(playlists, cached_playlists)
         while playlists['next']:
             playlists = self.sp.next(playlists)
-            self._sort_songs_helper(playlists, cached_playlists)
+            self._cache_songs_helper(playlists, cached_playlists)
 
         return cached_playlists
 
@@ -117,13 +117,11 @@ class SpotipyManager:
             tracks = self.sp.playlist_tracks(playlist['uri'])
             track_uris = set()
             for track in tracks['items']:
-                track_uris.add(track['uri'])
+                track_uris.add(track['track']['uri'])
             while tracks['next']:
                 tracks = self.sp.next(tracks)
                 for track in tracks['items']:
-                    track_uris.add(track['uri'])
+                    track_uris.add(track['track']['uri'])
 
             # Adds to dict
             dict_to_modify[playlist['uri']] = track_uris
-
-

--- a/src/spotipy_manager.py
+++ b/src/spotipy_manager.py
@@ -46,7 +46,7 @@ class SpotipyManager:
         :param uri: Unique id of object
         :return: Name of object from uri
         """
-        matched_uri = re.search('spotify:(track|playlist|album|artist):.*', uri)
+        matched_uri = re.search(r'spotify:(track|playlist|album|artist):.*', uri)
         if matched_uri:
             # Format of uri is spotify:type:id
             uri_type = matched_uri.group(1)

--- a/src/spotipy_manager.py
+++ b/src/spotipy_manager.py
@@ -92,3 +92,38 @@ class SpotipyManager:
                     tracks = self.sp.next(tracks)
                     if is_track_in_tracks(song_uri, tracks):
                         set_to_modify.add(playlist['uri'])
+
+    def cache_songs_in_playlists(self, playlists):
+        """
+        Creates playlists format that takes less time to determine if track is within a playlist
+        :param playlists: Page object of playlists to iterate over
+        :return: Dict mapping playlist uri to set of track uris that are within that playlist
+        """
+        cached_playlists = {}  # Maps playlist uri to a set of track uri's
+        self._sort_songs_helper(playlists, cached_playlists)
+        while playlists['next']:
+            playlists = self.sp.next(playlists)
+            self._sort_songs_helper(playlists, cached_playlists)
+
+        return cached_playlists
+
+    def _cache_songs_helper(self, playlists, dict_to_modify):
+        """
+        Iterates over the tracks within the playlists and places them within a set for quicker accessing
+        :param playlists: Page object of playlists to iterate over
+        :param dict_to_modify: Dict that stores the cached playlists
+        """
+        for playlist in playlists['items']:
+            tracks = self.sp.playlist_tracks(playlist['uri'])
+            track_uris = set()
+            for track in tracks['items']:
+                track_uris.add(track['uri'])
+            while tracks['next']:
+                tracks = self.sp.next(tracks)
+                for track in tracks['items']:
+                    track_uris.add(track['uri'])
+
+            # Adds to dict
+            dict_to_modify[playlist['uri']] = track_uris
+
+

--- a/test/test_spotipy_manager.py
+++ b/test/test_spotipy_manager.py
@@ -5,15 +5,15 @@ from src.spotipy_manager import *
 class TestSpotipyManager(unittest.TestCase):
     def setUp(self):
         self.spm = SpotipyManager()
+        self.sp = self.spm.get_spotipy_client()
 
     def test_is_track_in_tracks(self):
-        sp = self.spm.get_spotipy_client()
         song_uri = 'spotify:track:0K8ML5cB3rGmNe1oOVTXPo'  # Melancolia by Caravan Palace
-        album = sp.album('spotify:album:5Pnctsm9Mi4D6W3DzWckA6')  # Album song is in
+        album = self.sp.album('spotify:album:5Pnctsm9Mi4D6W3DzWckA6')  # Album song is in
         self.assertTrue(is_track_in_tracks(song_uri, album['tracks']))
 
-        playlist = sp.playlist('spotify:playlist:37i9dQZF1DWYkaDif7Ztbp')  # African Heat Playlist
-        self.assertFalse(is_track_in_tracks(song_uri, sp.playlist_tracks(playlist['id'])))
+        playlist = self.sp.playlist('spotify:playlist:37i9dQZF1DWYkaDif7Ztbp')  # African Heat Playlist
+        self.assertFalse(is_track_in_tracks(song_uri, self.sp.playlist_tracks(playlist['id'])))
 
     def test_get_name_from_uri(self):
         self.assertEqual(self.spm.get_name_from_uri('spotify:track:5l08slmvFRUseHpq85neke'), 'NaNa', 'Track URI')
@@ -41,6 +41,17 @@ class TestSpotipyManager(unittest.TestCase):
         correct_set.add('spotify:playlist:37i9dQZF1Etq2nOAOxQGnV')
 
         self.assertEqual(playlists, correct_set)
+
+    def test_cache_songs_in_playlists(self):
+        playlists = self.sp.current_user_playlists()
+        cached_playlists = self.spm.cache_songs_in_playlists(playlists)
+
+        test_playlist_cached = cached_playlists['spotify:playlist:0YhxBIhx9BrFMrnAWL72PQ']
+        correct_set = {'spotify:track:14dCt3xXZvmoqorYnxspSj',
+                       'spotify:track:6WtiJthSHfbA5RIWcUU4TM',
+                       'spotify:track:2ZltjIqztEpZtafc8w0I9t',
+                       'spotify:track:5pS3GKYhlEAqSYM8JM27ki'}
+        self.assertEqual(test_playlist_cached, correct_set, 'SPS_TEST Playlist')
 
 
 if __name__ == '__main__':

--- a/test/test_spotipy_manager.py
+++ b/test/test_spotipy_manager.py
@@ -1,7 +1,7 @@
 import unittest
 from src.spotipy_manager import *
 
-
+# TODO Get specific user's playlists rather than current user's for testing
 class TestSpotipyManager(unittest.TestCase):
     def setUp(self):
         self.spm = SpotipyManager()


### PR DESCRIPTION
Implement the caching of the user's playlists and the tracks within them in a format that vastly improves search times. The track uri's are within a set instead of a list which is the main reason for the drastic decrease in time taken for the algorithm.

Also, a switch from json to pickle for the settings and cache-playlists file has been done. This is due to json not being able to serialize a Python set or a datetime object.

Nothing as of right now is done with the fact that the cache-playlists file stores the time it was last updated but it allows for the cache to only update after a set amount of time has passed. Might be a good next feature to add.